### PR TITLE
Update release version to Julia v0.5

### DIFF
--- a/lib/travis/build/script/julia.rb
+++ b/lib/travis/build/script/julia.rb
@@ -100,7 +100,7 @@ module Travis
             case config[:julia].to_s
             when 'release'
               # CHANGEME on new minor releases (once or twice a year)
-              url = "s3.amazonaws.com/julialang/bin/#{osarch}/0.4/julia-0.4-latest-#{ext}"
+              url = "s3.amazonaws.com/julialang/bin/#{osarch}/0.5/julia-0.5-latest-#{ext}"
             when 'nightly'
               url = "s3.amazonaws.com/julianightlies/bin/#{osarch}/julia-latest-#{nightlyext}"
             when /^(\d+\.\d+)\.\d+$/


### PR DESCRIPTION
With the release of Julia v0.5, I think this is how the Travis build should deal with `release`.

Pinging @tkelman, @ninjin, @staticfloat, and @simonbyrne as suggested by my Travis output.
